### PR TITLE
MENO import

### DIFF
--- a/oeo-imports/meno/extract-meno-module.sh
+++ b/oeo-imports/meno/extract-meno-module.sh
@@ -1,0 +1,25 @@
+tmpdir=tmp
+mkdir -p ${tmpdir}
+
+this_wd=oeo-tools/oeo-imports/meno
+ontology_source=src/ontology
+imports="${ontology_source}/imports"
+
+# Download the MENO version of the commit behind release from 2024-03-19
+curl -L https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/refs/heads/dev/ontology/src/midlevel-energy.owl > ${tmpdir}/meno-full-download.owl
+# Extract the terms we want with their hierarchy of subclasses
+robot merge --input ${tmpdir}/meno-full-download.owl extract --method MIREOT --branch-from-terms ${this_wd}/meno-extract-w-hierarchy.txt --intermediates all --output ${tmpdir}/meno-extracted-w-hierarchy.owl
+# Extract the terms we want without their hierarchy of subclasses or subproperties
+robot merge --input ${tmpdir}/meno-full-download.owl extract --method MIREOT --lower-terms ${this_wd}/meno-extract-n-hierarchy.txt --intermediates none --output ${tmpdir}/meno-extracted-n-hierarchy.owl
+# Create Extracted module and annotate with new ontology information
+robot merge --input ${tmpdir}/meno-extracted-w-hierarchy.owl --input ${tmpdir}/meno-extracted-n-hierarchy.owl annotate --ontology-iri http://openenergy-platform.org/ontology/oeo/imports/meno-extracted.owl --version-iri http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl --output ${tmpdir}/meno-extracted.owl
+# Annotates the output module with a commentary to the origin of the content
+robot annotate --input ${tmpdir}/meno-extracted.owl --annotation rdfs:comment "This file contains externally imported content from the Midlevel Energy Ontology (MENO) for import into the Open Energy Ontology (OEO). It is automatically extracted using ROBOT from the list of selected terms (meno-extract-w-hierarchy.txt, meno-extract-n-hierarchy.txt) located in the OEO-tools repository." --output ${tmpdir}/meno-extracted.owl
+# Annotates each axiom with the ontology IRI, using prov:wasDerivedFrom
+robot annotate --input ${tmpdir}/meno-extracted.owl --annotate-derived-from true --annotate-defined-by true --output ${imports}/meno-extracted.owl
+
+rm ${tmpdir}/meno-full-download.owl
+rm ${tmpdir}/meno-extracted-w-hierarchy.owl
+rm ${tmpdir}/meno-extracted-n-hierarchy.owl
+rm ${tmpdir}/meno-extracted.owl
+rmdir ${tmpdir}

--- a/oeo-imports/meno/meno-extract-n-hierarchy.txt
+++ b/oeo-imports/meno/meno-extract-n-hierarchy.txt
@@ -1,3 +1,7 @@
 https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01004 # 'energetic conversion process'
 https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01013 # 'energy decrease'
 https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01014 # 'energy increase'
+https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01039 # 'quality transformation'
+https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01003 # 'energy transformation'
+https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01043 # 'combustion'
+

--- a/oeo-imports/meno/meno-extract-n-hierarchy.txt
+++ b/oeo-imports/meno/meno-extract-n-hierarchy.txt
@@ -1,0 +1,3 @@
+https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01004 # 'energetic conversion process'
+https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01013 # 'energy decrease'
+https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01014 # 'energy increase'

--- a/oeo-imports/meno/meno-extract-w-hierarchy.txt
+++ b/oeo-imports/meno/meno-extract-w-hierarchy.txt
@@ -1,2 +1,1 @@
 https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01038 # 'quality transfer' + subclasses
-https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01039 # 'quality transformation' + subclasses

--- a/oeo-imports/meno/meno-extract-w-hierarchy.txt
+++ b/oeo-imports/meno/meno-extract-w-hierarchy.txt
@@ -1,0 +1,2 @@
+https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01038 # 'quality transfer' + subclasses
+https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01039 # 'quality transformation' + subclasses

--- a/oeo-imports/meno/meno-extracted.owl
+++ b/oeo-imports/meno/meno-extracted.owl
@@ -1,0 +1,756 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns="http://openenergy-platform.org/ontology/oeo/imports/meno-extracted.owl#"
+     xml:base="http://openenergy-platform.org/ontology/oeo/imports/meno-extracted.owl"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:prov="http://www.w3.org/ns/prov#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">
+    <owl:Ontology rdf:about="http://openenergy-platform.org/ontology/oeo/imports/meno-extracted.owl">
+        <owl:versionIRI rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+        <rdfs:comment>This file contains externally imported content from the Midlevel Energy Ontology (MENO) for import into the Open Energy Ontology (OEO). It is automatically extracted using ROBOT from the list of selected terms (meno-extract-w-hierarchy.txt, meno-extract-n-hierarchy.txt) located in the OEO-tools repository.</rdfs:comment>
+    </owl:Ontology>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotation properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000114 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000114">
+        <rdfs:isDefinedBy rdf:resource="http://openenergy-platform.org/ontology/oeo/imports/meno-extracted.owl"/>
+    </owl:AnnotationProperty>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/IAO_0000114"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label>definition</rdfs:label>
+        <rdfs:label xml:lang="en">definition</rdfs:label>
+    </owl:AnnotationProperty>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#isDefinedBy"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+        <owl:annotatedTarget>definition</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+        <owl:annotatedTarget xml:lang="en">definition</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000589 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000589">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <rdfs:isDefinedBy rdf:resource="http://openenergy-platform.org/ontology/oeo/imports/meno-extracted.owl"/>
+        <rdfs:label xml:lang="en">OBO foundry unique label</rdfs:label>
+    </owl:AnnotationProperty>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/IAO_0000589"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/IAO_0000589"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000114"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/IAO_0000589"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+        <owl:annotatedTarget xml:lang="en">OBO foundry unique label</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000600 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000600">
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">elucidation</rdfs:label>
+    </owl:AnnotationProperty>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#isDefinedBy"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+        <owl:annotatedTarget xml:lang="en">elucidation</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000602 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000602">
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">has associated axiom(fol)</rdfs:label>
+    </owl:AnnotationProperty>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#isDefinedBy"/>
+        <owl:annotatedTarget rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+        <owl:annotatedTarget xml:lang="en">has associated axiom(fol)</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://www.w3.org/2000/01/rdf-schema#isDefinedBy -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#isDefinedBy">
+        <obo:IAO_0000589>is defined by</obo:IAO_0000589>
+    </owl:AnnotationProperty>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://www.w3.org/2000/01/rdf-schema#isDefinedBy"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://www.w3.org/2000/01/rdf-schema#isDefinedBy"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000589"/>
+        <owl:annotatedTarget>is defined by</owl:annotatedTarget>
+        <rdfs:comment>This is an experimental annotation</rdfs:comment>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://www.w3.org/2000/01/rdf-schema#label -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#label"/>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#AnnotationProperty"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    
+
+
+    <!-- http://www.w3.org/ns/prov#wasDerivedFrom -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/ns/prov#wasDerivedFrom">
+        <rdfs:isDefinedBy rdf:resource="http://openenergy-platform.org/ontology/oeo/imports/meno-extracted.owl"/>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01002 -->
+
+    <owl:Class rdf:about="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01002">
+        <rdfs:subClassOf rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01038"/>
+        <obo:IAO_0000115>Energy transfer is a quality process in which a kind of energy is decreased in one bearer and the same kind of energy is increased in another bearer.</obo:IAO_0000115>
+        <rdfs:isDefinedBy rdf:resource="http://openenergy-platform.org/ontology/oeo/imports/meno-extracted.owl"/>
+        <rdfs:label>energy transfer</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01002"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01002"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01038"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01002"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>Energy transfer is a quality process in which a kind of energy is decreased in one bearer and the same kind of energy is increased in another bearer.</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01002"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+        <owl:annotatedTarget>energy transfer</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    
+
+
+    <!-- https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01003 -->
+
+    <owl:Class rdf:about="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01003">
+        <rdfs:subClassOf rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01039"/>
+        <obo:IAO_0000115>Energy transformation is a process in which one type of energy is decreased, and simultaneously within the same bearer one or more other types of energy are increased.</obo:IAO_0000115>
+        <obo:IAO_0000602>(forall (?et) (iff (EnergyTransformation ?et)  
+  (exists (?ed ?ei ?en1 ?en2 ?me) 
+    (and (EnergyDecrease ?ed) (has_part ?et ?ed) 
+      (EnergyIncrease ?ei) (has_part ?et ?ei)
+      (causally_related_to ?ed ?ei)            
+      (Energy ?en1) (Energy ?en2) (not (= ?en1 ?en2))
+      (negatively_regulates ?ed ?en1) 
+      (positively_regulates ?ei ?en2)  
+      (MaterialEntity ?me) 
+      (has_participant ?ed ?me) (has_participant ?ei ?me) 
+      (inheres_in ?en1 ?me) (inheres_in ?en2 ?me) ))))</obo:IAO_0000602>
+        <rdfs:isDefinedBy rdf:resource="http://openenergy-platform.org/ontology/oeo/imports/meno-extracted.owl"/>
+        <rdfs:label>energy transformation</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01003"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01003"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01039"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01003"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>Energy transformation is a process in which one type of energy is decreased, and simultaneously within the same bearer one or more other types of energy are increased.</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01003"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
+        <owl:annotatedTarget>(forall (?et) (iff (EnergyTransformation ?et)  
+  (exists (?ed ?ei ?en1 ?en2 ?me) 
+    (and (EnergyDecrease ?ed) (has_part ?et ?ed) 
+      (EnergyIncrease ?ei) (has_part ?et ?ei)
+      (causally_related_to ?ed ?ei)            
+      (Energy ?en1) (Energy ?en2) (not (= ?en1 ?en2))
+      (negatively_regulates ?ed ?en1) 
+      (positively_regulates ?ei ?en2)  
+      (MaterialEntity ?me) 
+      (has_participant ?ed ?me) (has_participant ?ei ?me) 
+      (inheres_in ?en1 ?me) (inheres_in ?en2 ?me) ))))</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01003"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+        <owl:annotatedTarget>energy transformation</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    
+
+
+    <!-- https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01004 -->
+
+    <owl:Class rdf:about="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01004">
+        <obo:IAO_0000115>Energetic conversion process is a process that has energy transfers or energy transformations (or both) as part.</obo:IAO_0000115>
+        <obo:IAO_0000600>Energetic conversion processes comprise any non-idealised processes. The term &apos;energetic conversion&apos; is chosen as collective term for energy transformations and energy transfers. However, literature is ambiguous in its interpretation. Some sources refer to energy conversion as synonym for energy transformation.</obo:IAO_0000600>
+        <rdfs:isDefinedBy rdf:resource="http://openenergy-platform.org/ontology/oeo/imports/meno-extracted.owl"/>
+        <rdfs:label>energetic conversion process</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01004"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01004"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>Energetic conversion process is a process that has energy transfers or energy transformations (or both) as part.</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01004"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000600"/>
+        <owl:annotatedTarget>Energetic conversion processes comprise any non-idealised processes. The term &apos;energetic conversion&apos; is chosen as collective term for energy transformations and energy transfers. However, literature is ambiguous in its interpretation. Some sources refer to energy conversion as synonym for energy transformation.</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01004"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+        <owl:annotatedTarget>energetic conversion process</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    
+
+
+    <!-- https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01013 -->
+
+    <owl:Class rdf:about="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01013">
+        <obo:IAO_0000115>Energy decrease is a quality decrease which negatively regulates an energy.</obo:IAO_0000115>
+        <rdfs:isDefinedBy rdf:resource="http://openenergy-platform.org/ontology/oeo/imports/meno-extracted.owl"/>
+        <rdfs:label>energy decrease</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01013"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01013"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>Energy decrease is a quality decrease which negatively regulates an energy.</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01013"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+        <owl:annotatedTarget>energy decrease</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    
+
+
+    <!-- https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01014 -->
+
+    <owl:Class rdf:about="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01014">
+        <obo:IAO_0000115>Energy increase is a quality increase which positively regulates an energy.</obo:IAO_0000115>
+        <rdfs:isDefinedBy rdf:resource="http://openenergy-platform.org/ontology/oeo/imports/meno-extracted.owl"/>
+        <rdfs:label>energy increase</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01014"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01014"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>Energy increase is a quality increase which positively regulates an energy.</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01014"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+        <owl:annotatedTarget>energy increase</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    
+
+
+    <!-- https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01038 -->
+
+    <owl:Class rdf:about="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01038">
+        <obo:IAO_0000115>Quality transfer is a process in which one quality is decreased in one bearer and, causally interconnected, another quality that inheres in a different bearer is increased.</obo:IAO_0000115>
+        <obo:IAO_0000602>(forall (?et) (iff (QualityTransfer ?et)  
+  (exists (?ed ?ei ?en1 ?en2 ?me1 ?me2) 
+    (and (QualityDecrease ?ed) (has_part ?et ?ed) 
+      (QualityIncrease ?ei) (has_part ?et ?ei)
+      (causally_related_to ?ed ?ei)            
+      (Quality ?en1) (negatively_regulates ?ed ?en1) 
+      (Quality ?en2) (positively_regulates ?ei ?en2)  
+      (MaterialEntity ?me1) (MaterialEntity ?me2) 
+      (not (= ?me1 ?me2)) (not (= ?en1 ?en2))
+      (has_participant ?ed ?me1) (inheres_in ?en1 ?me1) 
+      (has_participant ?ei ?me2) (inheres_in ?en2 ?me2) ))))</obo:IAO_0000602>
+        <rdfs:isDefinedBy rdf:resource="http://openenergy-platform.org/ontology/oeo/imports/meno-extracted.owl"/>
+        <rdfs:label>quality transfer</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01038"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01038"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>Quality transfer is a process in which one quality is decreased in one bearer and, causally interconnected, another quality that inheres in a different bearer is increased.</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01038"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
+        <owl:annotatedTarget>(forall (?et) (iff (QualityTransfer ?et)  
+  (exists (?ed ?ei ?en1 ?en2 ?me1 ?me2) 
+    (and (QualityDecrease ?ed) (has_part ?et ?ed) 
+      (QualityIncrease ?ei) (has_part ?et ?ei)
+      (causally_related_to ?ed ?ei)            
+      (Quality ?en1) (negatively_regulates ?ed ?en1) 
+      (Quality ?en2) (positively_regulates ?ei ?en2)  
+      (MaterialEntity ?me1) (MaterialEntity ?me2) 
+      (not (= ?me1 ?me2)) (not (= ?en1 ?en2))
+      (has_participant ?ed ?me1) (inheres_in ?en1 ?me1) 
+      (has_participant ?ei ?me2) (inheres_in ?en2 ?me2) ))))</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01038"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+        <owl:annotatedTarget>quality transfer</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    
+
+
+    <!-- https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01039 -->
+
+    <owl:Class rdf:about="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01039">
+        <obo:IAO_0000115>Quality transformation is a process in which one quality is decreased, and, causally interconnected, one or more qualities are increased and all of these qualities inhere in the same bearer.</obo:IAO_0000115>
+        <obo:IAO_0000602>(forall (?et) (iff (QualityTransformation ?et)  
+  (exists (?ed ?ei ?en1 ?en2 ?me) 
+    (and (QualityDecrease ?ed) (has_part ?et ?ed) 
+      (QualityIncrease ?ei) (has_part ?et ?ei)
+      (causally_related_to ?ed ?ei)            
+      (Quality ?en1) (Quality ?en2) (not (= ?en1 ?en2))
+      (negatively_regulates ?ed ?en1) 
+      (positively_regulates ?ei ?en2)  
+      (MaterialEntity ?me) 
+      (has_participant ?ed ?me) (has_participant ?ei ?me) 
+      (inheres_in ?en1 ?me) (inheres_in ?en2 ?me) ))))</obo:IAO_0000602>
+        <rdfs:isDefinedBy rdf:resource="http://openenergy-platform.org/ontology/oeo/imports/meno-extracted.owl"/>
+        <rdfs:label>quality transformation</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01039"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01039"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>Quality transformation is a process in which one quality is decreased, and, causally interconnected, one or more qualities are increased and all of these qualities inhere in the same bearer.</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01039"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000602"/>
+        <owl:annotatedTarget>(forall (?et) (iff (QualityTransformation ?et)  
+  (exists (?ed ?ei ?en1 ?en2 ?me) 
+    (and (QualityDecrease ?ed) (has_part ?et ?ed) 
+      (QualityIncrease ?ei) (has_part ?et ?ei)
+      (causally_related_to ?ed ?ei)            
+      (Quality ?en1) (Quality ?en2) (not (= ?en1 ?en2))
+      (negatively_regulates ?ed ?en1) 
+      (positively_regulates ?ei ?en2)  
+      (MaterialEntity ?me) 
+      (has_participant ?ed ?me) (has_participant ?ei ?me) 
+      (inheres_in ?en1 ?me) (inheres_in ?en2 ?me) ))))</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01039"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+        <owl:annotatedTarget>quality transformation</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    
+
+
+    <!-- https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01040 -->
+
+    <owl:Class rdf:about="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01040">
+        <rdfs:subClassOf rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01002"/>
+        <obo:IAO_0000115>A radiation process is an energy transfer that transmits radiative energy as  electromagnetic waves. The transfer does not necessarily occur within a material entity.</obo:IAO_0000115>
+        <rdfs:isDefinedBy rdf:resource="http://openenergy-platform.org/ontology/oeo/imports/meno-extracted.owl"/>
+        <rdfs:label>radiation</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01040"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01040"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01002"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01040"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>A radiation process is an energy transfer that transmits radiative energy as  electromagnetic waves. The transfer does not necessarily occur within a material entity.</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01040"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+        <owl:annotatedTarget>radiation</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    
+
+
+    <!-- https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01041 -->
+
+    <owl:Class rdf:about="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01041">
+        <rdfs:subClassOf rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01002"/>
+        <obo:IAO_0000115>Electricity conduction is an energy transfer in which electrical energy is transmitted within a material entity or object aggregat, e.g. a cable.</obo:IAO_0000115>
+        <rdfs:isDefinedBy rdf:resource="http://openenergy-platform.org/ontology/oeo/imports/meno-extracted.owl"/>
+        <rdfs:label>electricity conduction</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01041"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01041"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01002"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01041"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>Electricity conduction is an energy transfer in which electrical energy is transmitted within a material entity or object aggregat, e.g. a cable.</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01041"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+        <owl:annotatedTarget>electricity conduction</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    
+
+
+    <!-- https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01042 -->
+
+    <owl:Class rdf:about="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01042">
+        <rdfs:subClassOf rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01002"/>
+        <obo:IAO_0000115>Heat convection is an energy transfer in which thermal energy is transported within flowing gaseous or liquid material entities.</obo:IAO_0000115>
+        <rdfs:isDefinedBy rdf:resource="http://openenergy-platform.org/ontology/oeo/imports/meno-extracted.owl"/>
+        <rdfs:label>heat convection</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01042"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01042"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01002"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01042"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>Heat convection is an energy transfer in which thermal energy is transported within flowing gaseous or liquid material entities.</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01042"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+        <owl:annotatedTarget>heat convection</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    
+
+
+    <!-- https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01043 -->
+
+    <owl:Class rdf:about="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01043">
+        <rdfs:subClassOf rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01003"/>
+        <obo:IAO_0000115>Combustion is an energy transformation in which chemical energy from a fuel is transformed into thermal energy and other kinds of energy, e.g. radiative energy.</obo:IAO_0000115>
+        <rdfs:isDefinedBy rdf:resource="http://openenergy-platform.org/ontology/oeo/imports/meno-extracted.owl"/>
+        <rdfs:label>combustion</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01043"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01043"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01003"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01043"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>Combustion is an energy transformation in which chemical energy from a fuel is transformed into thermal energy and other kinds of energy, e.g. radiative energy.</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01043"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+        <owl:annotatedTarget>combustion</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    
+
+
+    <!-- https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01044 -->
+
+    <owl:Class rdf:about="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01044">
+        <rdfs:subClassOf rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01003"/>
+        <obo:IAO_0000115>Photosynthesis is an energy transformation in which radiative (solar) energy is transformed into chemical energy within a plant.</obo:IAO_0000115>
+        <rdfs:isDefinedBy rdf:resource="http://openenergy-platform.org/ontology/oeo/imports/meno-extracted.owl"/>
+        <rdfs:label>photosynthesis</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01044"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01044"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01003"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01044"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>Photosynthesis is an energy transformation in which radiative (solar) energy is transformed into chemical energy within a plant.</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01044"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+        <owl:annotatedTarget>photosynthesis</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    
+
+
+    <!-- https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01045 -->
+
+    <owl:Class rdf:about="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01045">
+        <rdfs:subClassOf rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01003"/>
+        <obo:IAO_0000115>Falling is an energy transformation in which gravitational potential energy is transformed into kintetic energy.</obo:IAO_0000115>
+        <rdfs:isDefinedBy rdf:resource="http://openenergy-platform.org/ontology/oeo/imports/meno-extracted.owl"/>
+        <rdfs:label>falling</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01045"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01045"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01003"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01045"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>Falling is an energy transformation in which gravitational potential energy is transformed into kintetic energy.</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01045"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+        <owl:annotatedTarget>falling</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    
+
+
+    <!-- https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01049 -->
+
+    <owl:Class rdf:about="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01049">
+        <rdfs:subClassOf rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01002"/>
+        <obo:IAO_0000115>Heat conduction is an energy transfer in which thermal energy is transmitted within a material entity or object aggregat.</obo:IAO_0000115>
+        <rdfs:isDefinedBy rdf:resource="http://openenergy-platform.org/ontology/oeo/imports/meno-extracted.owl"/>
+        <rdfs:label>heat conduction</rdfs:label>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01049"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01049"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
+        <owl:annotatedTarget rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01002"/>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01049"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>Heat conduction is an energy transfer in which thermal energy is transmitted within a material entity or object aggregat.</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01049"/>
+        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+        <owl:annotatedTarget>heat conduction</owl:annotatedTarget>
+        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
+    </owl:Axiom>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 4.5.29) https://github.com/owlcs/owlapi -->
+

--- a/oeo-imports/meno/meno-extracted.owl
+++ b/oeo-imports/meno/meno-extracted.owl
@@ -246,7 +246,6 @@
     <!-- https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01003 -->
 
     <owl:Class rdf:about="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01003">
-        <rdfs:subClassOf rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01039"/>
         <obo:IAO_0000115>Energy transformation is a process in which one type of energy is decreased, and simultaneously within the same bearer one or more other types of energy are increased.</obo:IAO_0000115>
         <obo:IAO_0000602>(forall (?et) (iff (EnergyTransformation ?et)  
   (exists (?ed ?ei ?en1 ?en2 ?me) 
@@ -266,12 +265,6 @@
         <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01003"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
         <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01003"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01039"/>
         <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
     </owl:Axiom>
     <owl:Axiom>
@@ -614,7 +607,6 @@
     <!-- https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01043 -->
 
     <owl:Class rdf:about="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01043">
-        <rdfs:subClassOf rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01003"/>
         <obo:IAO_0000115>Combustion is an energy transformation in which chemical energy from a fuel is transformed into thermal energy and other kinds of energy, e.g. radiative energy.</obo:IAO_0000115>
         <rdfs:isDefinedBy rdf:resource="http://openenergy-platform.org/ontology/oeo/imports/meno-extracted.owl"/>
         <rdfs:label>combustion</rdfs:label>
@@ -627,12 +619,6 @@
     </owl:Axiom>
     <owl:Axiom>
         <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01043"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01003"/>
-        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01043"/>
         <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
         <owl:annotatedTarget>Combustion is an energy transformation in which chemical energy from a fuel is transformed into thermal energy and other kinds of energy, e.g. radiative energy.</owl:annotatedTarget>
         <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
@@ -641,76 +627,6 @@
         <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01043"/>
         <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
         <owl:annotatedTarget>combustion</owl:annotatedTarget>
-        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
-    </owl:Axiom>
-    
-
-
-    <!-- https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01044 -->
-
-    <owl:Class rdf:about="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01044">
-        <rdfs:subClassOf rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01003"/>
-        <obo:IAO_0000115>Photosynthesis is an energy transformation in which radiative (solar) energy is transformed into chemical energy within a plant.</obo:IAO_0000115>
-        <rdfs:isDefinedBy rdf:resource="http://openenergy-platform.org/ontology/oeo/imports/meno-extracted.owl"/>
-        <rdfs:label>photosynthesis</rdfs:label>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01044"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01044"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01003"/>
-        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01044"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget>Photosynthesis is an energy transformation in which radiative (solar) energy is transformed into chemical energy within a plant.</owl:annotatedTarget>
-        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01044"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
-        <owl:annotatedTarget>photosynthesis</owl:annotatedTarget>
-        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
-    </owl:Axiom>
-    
-
-
-    <!-- https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01045 -->
-
-    <owl:Class rdf:about="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01045">
-        <rdfs:subClassOf rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01003"/>
-        <obo:IAO_0000115>Falling is an energy transformation in which gravitational potential energy is transformed into kintetic energy.</obo:IAO_0000115>
-        <rdfs:isDefinedBy rdf:resource="http://openenergy-platform.org/ontology/oeo/imports/meno-extracted.owl"/>
-        <rdfs:label>falling</rdfs:label>
-    </owl:Class>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01045"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
-        <owl:annotatedTarget rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01045"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#subClassOf"/>
-        <owl:annotatedTarget rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01003"/>
-        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01045"/>
-        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
-        <owl:annotatedTarget>Falling is an energy transformation in which gravitational potential energy is transformed into kintetic energy.</owl:annotatedTarget>
-        <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
-    </owl:Axiom>
-    <owl:Axiom>
-        <owl:annotatedSource rdf:resource="https://raw.githubusercontent.com/stap-m/midlevel-energy-ontology/main/ontology/src/midlevel-energy.owl/MENO_01045"/>
-        <owl:annotatedProperty rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
-        <owl:annotatedTarget>falling</owl:annotatedTarget>
         <prov:wasDerivedFrom rdf:resource="http://openenergy-platform.org/ontology/oeo/dev/imports/meno-extracted.owl"/>
     </owl:Axiom>
     


### PR DESCRIPTION
See issue #29 and [issue#1959](https://github.com/OpenEnergyPlatform/ontology/issues/1959) in the ontology repository.

This is an import from the MENO (mid-level energy ontology) as proposed in this [paper]( https://www.utwente.nl/en/eemcs/fois2024/resources/papers/stappel-neuhaus-representing-energy-in-the-midlevel-energy-ontology-meno.pdf).
The exact terms to be imported were discussed during oeo-dev-95 with @areleu and @stap-m.

Imported terms:
- energetic conversion process
- energy decrease
- energy increase
- quality transfer + subclasses
     - energy transfer
     - electricity conduction
     - heat conduction
     - heat convection
     - radiation
- quality transformation + subclasses
     - energy transformation
     - combustion
     - ~~falling~~
     - ~~photosynthesis~~

Falling and photosynthesis were taken out, due to their definitions and because they were out of scope for the OEO.
The discussion about these terms can be found [here](https://github.com/OpenEnergyPlatform/ontology/pull/2022#issuecomment-2677658629)

Closes #29 
