### PR TITLE
Exclude 'UO:0000000 unit' during extraction

### DIFF
--- a/oeo-imports/uo/extract-uo-module.sh
+++ b/oeo-imports/uo/extract-uo-module.sh
@@ -8,8 +8,9 @@ imports="${ontology_source}/imports"
 # Download UO release from 202
 #curl -L https://data.bioontology.org/ontologies/UO/submissions/219/download?apikey=8b5b7825-538d-40e0-9e9e-5ab9274a9aeb > ${tmpdir}/uo-full-download.owl
 curl -L http://purl.obolibrary.org/obo/uo.owl > ${tmpdir}/uo-full-download.owl
-# Extract the terms we want with downward hierarchy
-robot merge --input ${tmpdir}/uo-full-download.owl extract --method MIREOT --lower-terms ${this_wd}/uo-w-hierarchy.txt --intermediates all --output ${tmpdir}/uo-module-temp.owl
+# Extract the terms we want with downward hierarchy excluding the root term UO:0000000 as we use OEO:00010490 (see OpenEnergyPlatform/ontology/pull/2141)
+robot merge --input ${tmpdir}/uo-full-download.owl extract --method MIREOT --lower-terms ${this_wd}/uo-w-hierarchy.txt --intermediates all \
+    remove --term UO:0000000 --preserve-structure false --output ${tmpdir}/uo-module-temp.owl
 ## add prefix for OBO xmlns:obo="http://purl.obolibrary.org/obo/"
 sed -i 's/xmlns:owl/xmlns:obo="http:\/\/purl.obolibrary.org\/obo\/"\n\t \xmlns:owl/' tmp/uo-module-temp.owl
 # Replace "<rdfs:comment>" with "obo:IAO_0000115" and Replace "<rdfs:comment>" with "</obo:IAO_0000115>"


### PR DESCRIPTION
Removes `unit [UO:0000000]` during the import to complete https://github.com/OpenEnergyPlatform/ontology/pull/2141. The following 30 axioms will not be extracted from UO:


- `AnnotationAssertion(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) <http://purl.obolibrary.org/obo/IAO_0000115> UO:0000000 "\"A unit of measurement is a standardized quantity of a physical quality.\" [Wikipedia:Wikipedia]")`
- `AnnotationAssertion(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) rdfs:label UO:0000000 "unit")`
- `AnnotationAssertion(rdfs:isDefinedBy UO:0000000 <http://purl.obolibrary.org/obo/uo.owl>)`
- `Declaration(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) Class(UO:0000000))`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000000 owl:Thing)`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000001 UO:0000000)`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000002 UO:0000000)`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000003 UO:0000000)`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000004 UO:0000000)`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000005 UO:0000000)`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000045 UO:0000000)`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000047 UO:0000000)`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000051 UO:0000000)`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000060 UO:0000000)`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000095 UO:0000000)`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000105 UO:0000000)`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000107 UO:0000000)`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000109 UO:0000000)`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000111 UO:0000000)`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000113 UO:0000000)`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000121 UO:0000000)`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000157 UO:0000000)`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000182 UO:0000000)`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000186 UO:0000000)`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000217 UO:0000000)`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000219 UO:0000000)`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000231 UO:0000000)`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000261 UO:0000000)`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000270 UO:0000000)`
- `SubClassOf(Annotation(PROV:wasDerivedFrom <http://.../uo.owl>) UO:0000280 UO:0000000)`

Thus, the extracted direct subclasses of UO:unit will have no declared super class in the extracted module.